### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A MCP server project
 
+<a href="https://glama.ai/mcp/servers/sgcdww166l"><img width="380" height="200" src="https://glama.ai/mcp/servers/sgcdww166l/badge" alt="browser-use server MCP server" /></a>
+
 ## Components
 
 ### Resources


### PR DESCRIPTION
This PR adds a badge for the [browser-use MCP server](https://glama.ai/mcp/servers/sgcdww166l) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/sgcdww166l"><img width="380" height="200" src="https://glama.ai/mcp/servers/sgcdww166l/badge" alt="browser-use server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.